### PR TITLE
Describe auto-termination more implicitly #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,46 +256,36 @@ The algorithm is modified as follows.
 
 ### Fetch termination initiated by the user agent
 
-A ReadableByteStream _s_ is said to be __observable__ when one of the following holds:
+The user agent may terminate the ongoing fetch with reason _garbage collection_ if that termination is not observable through the promise which the function returned.
 
-- _s_ is reachable from the Garbage Collector.
-- [IsReadableStreamLocked] (https://streams.spec.whatwg.org/#is-readable-stream-locked)(_s_) is __true__.
-
-Let _response_ be the response defined in the [fetch method steps](https://fetch.spec.whatwg.org/#dom-global-fetch). The user agent may terminate the fetch with which _response_ is associated with reason _garbage collection_ if the followings hold:
-
- - _response_'s type is not _error_.
- - The associated body of the [Response](https://fetch.spec.whatwg.org/#response_class) object associated to _response_ is not observable.
-
-Note: The intention here is that once the developer acquires a reader for the body stream, they have taken responsibility for resource management into their own hands, and plan to call `reader.cancel()` if they are no longer interested in consuming the body.
+Note: Although the server to which the fetch is connected can observe the termination, the user agent may terminate the fetch.
 
 (Example)
 
 ```
-// The user agent may terminate the fetch because the associated body
-// is not observable.
+// The user agent may terminate the fetch because the termination cannot
+// be observed.
 fetch("http://www.example.com/")
 
-// The user agent must not terminate the fetch because the associated
-// body is reachable by the garbage collector.
+// The user agent must note terminate the fetch because the termination can be
+// observed through the promise.
 window.promise = fetch("http://www.example.com/")
 
 // The user agent may terminate the fetch because the associated body
 // is not observable.
 window.promise = fetch("http://www.example.com/").then(res => res.headers)
 
-// The user agent must not terminate the fetch because there is an
-// active reader while it is not reachable by the garbage collector.
-fetch("http://www.example.com/").then(res => res.body.getReader())
+// The user agent may terminate the fetch because the termination cannot
+// be observed.
+fetch("http://www.example.com/").then(res => res.body.getReader().closed)
 
-// The user agent may terminate the fetch because the reader is not
-// active.
-fetch("http://www.example.com/")
-  .then(res => res.body.getReader().releaseLock())
+// The user agent must not terminate the fetch because once can observe the
+// termination by registering a handler to the promise object.
+window.promise = fetch("http://www.example.com/").then(res =>
+  res.body.getReader().closed)
 
-// The user agent must not terminate the fetch because there is an
-// active reader. Even though the reader is not reachable by the garbage
-// collector, the reader has been used to make termination observable, so
-// if termination occurred on GC, that would make GC observable.
+// The user agent must not terminate the fetch termination would be observable
+// via the registered handler.
 fetch("http://www.example.com/").then(res => {
   res.body.getReader().closed.then(() => console.log("stream closed!"))
 })

--- a/README.md
+++ b/README.md
@@ -256,35 +256,35 @@ The algorithm is modified as follows.
 
 ### Fetch termination initiated by the user agent
 
-The user agent may terminate the ongoing fetch with reason _garbage collection_ if that termination is not observable through the promise which the function returned.
+The user agent may terminate an ongoing fetch with reason _garbage collection_ if that termination is not observable through script.
 
-Note: Although the server to which the fetch is connected can observe the termination, the user agent may terminate the fetch.
+Note: The server observing garbage collection has precedent, e.g. with WebSocket and XMLHttpRequest.
 
 (Example)
 
 ```
-// The user agent may terminate the fetch because the termination cannot
+// The user agent can terminate the fetch because the termination cannot
 // be observed.
 fetch("http://www.example.com/")
 
-// The user agent must note terminate the fetch because the termination can be
+// The user agent cannot terminate the fetch because the termination can be
 // observed through the promise.
 window.promise = fetch("http://www.example.com/")
 
-// The user agent may terminate the fetch because the associated body
+// The user agent can terminate the fetch because the associated body
 // is not observable.
 window.promise = fetch("http://www.example.com/").then(res => res.headers)
 
-// The user agent may terminate the fetch because the termination cannot
+// The user agent can terminate the fetch because the termination cannot
 // be observed.
 fetch("http://www.example.com/").then(res => res.body.getReader().closed)
 
-// The user agent must not terminate the fetch because once can observe the
-// termination by registering a handler to the promise object.
+// The user agent cannot terminate the fetch because one can observe the
+// termination by registering a handler for the promise object.
 window.promise = fetch("http://www.example.com/").then(res =>
   res.body.getReader().closed)
 
-// The user agent must not terminate the fetch termination would be observable
+// The user agent cannot terminate the fetch as termination would be observable
 // via the registered handler.
 fetch("http://www.example.com/").then(res => {
   res.body.getReader().closed.then(() => console.log("stream closed!"))


### PR DESCRIPTION
Instead of describe conditions explicitely, describe them in a more implicit
way in order to allow implementers' optimizations.